### PR TITLE
Resolves an error during 'mvn install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd zxing-master/javase
 wget http://central.maven.org/maven2/com/google/zxing/javase/2.2/javase-2.2.jar 
 mv javase-2.2.jar javase.jar # Rename
 mvn install
-git@github.com:ankita-kumari/python-zxing.git
+git clone git://github.com/oostendo/python-zxing.git
 ```
 
 The library consists of two classes, BarCodeReader and BarCode.  BarCode parses

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ If you need to threshold or filter your image prior to sending to ZXing, I recom
 ```
 git clone https://github.com/zxing/zxing.git
 cd zxing-master
-git clone git://github.com/oostendo/python-zxing.git
 mvn install
 cd core
 wget http://central.maven.org/maven2/com/google/zxing/core/2.2/core-2.2.jar
@@ -21,6 +20,7 @@ cd zxing-master/javase
 wget http://central.maven.org/maven2/com/google/zxing/javase/2.2/javase-2.2.jar 
 mv javase-2.2.jar javase.jar # Rename
 mvn install
+git@github.com:ankita-kumari/python-zxing.git
 ```
 
 The library consists of two classes, BarCodeReader and BarCode.  BarCode parses


### PR DESCRIPTION
I kept getting this error: 
`Failed to execute goal org.apache.rat:apache-rat-plugin:0.11:check (default) on project zxing-parent: Too many files with unapproved license:`
Turns out all the files with unapprroved licenses were in the python-zxing folder. Cloning that particular repo at the end solved the issue. It was not clear in the initial README.
